### PR TITLE
Upgrade version of antlr4

### DIFF
--- a/packages/trevas/package.json
+++ b/packages/trevas/package.json
@@ -26,7 +26,7 @@
 	},
 	"dependencies": {
 		"@inseefr/vtl-2.0-antlr-tools": "0.1.0",
-		"antlr4": "4.8.0",
+		"antlr4": "4.13.0",
 		"data-forge": "^1.8.8",
 		"date-fns": "^2.27.0"
 	}

--- a/packages/trevas/src/errors/CastTypeError.js
+++ b/packages/trevas/src/errors/CastTypeError.js
@@ -1,4 +1,4 @@
-import { RecognitionException } from 'antlr4/error';
+import { RecognitionException } from 'antlr4';
 
 class CastTypeError extends RecognitionException {
 	constructor(ctx, source, target) {

--- a/packages/trevas/src/errors/IncompatibleTypeError.js
+++ b/packages/trevas/src/errors/IncompatibleTypeError.js
@@ -1,4 +1,4 @@
-import { RecognitionException } from 'antlr4/error';
+import { RecognitionException } from 'antlr4';
 import { getTokenName } from '../utils';
 
 class IncompatibleTypeError extends RecognitionException {

--- a/packages/trevas/src/errors/OperatorTypeError.js
+++ b/packages/trevas/src/errors/OperatorTypeError.js
@@ -1,4 +1,4 @@
-import { RecognitionException } from 'antlr4/error';
+import { RecognitionException } from 'antlr4';
 import { getTokenName } from '../utils';
 
 class OperatorTypeError extends RecognitionException {

--- a/packages/trevas/src/errors/TypeMismatchError.js
+++ b/packages/trevas/src/errors/TypeMismatchError.js
@@ -1,4 +1,4 @@
-import { RecognitionException } from 'antlr4/error';
+import { RecognitionException } from 'antlr4';
 import { getTokenName } from '../utils';
 
 class TypeMismatchError extends RecognitionException {

--- a/packages/trevas/src/interpretor.js
+++ b/packages/trevas/src/interpretor.js
@@ -1,8 +1,7 @@
-import antlr4 from 'antlr4';
-import { ErrorListener } from 'antlr4/error';
 import { VtlLexer, VtlParser } from '@inseefr/vtl-2.0-antlr-tools';
-import ExpressionVisitor from './visitors/Expression';
+import antlr4, { ErrorListener } from 'antlr4';
 import { getTokenName } from './utils/parser';
+import ExpressionVisitor from './visitors/Expression';
 
 class ErrorCollector extends ErrorListener {
 	constructor() {

--- a/packages/vtl-2.0-antlr-tools/package.json
+++ b/packages/vtl-2.0-antlr-tools/package.json
@@ -20,7 +20,7 @@
 		"analyze": "yarn build && source-map-explorer lib/index.js --html bundle-report/vtl-2.0-antlr-tools.html"
 	},
 	"dependencies": {
-		"antlr4": "4.8.0"
+		"antlr4": "4.13.0"
 	},
 	"devDependencies": {
 		"antlr4-tool": "^1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2809,15 +2809,15 @@ antlr4-tool@^1.1.1:
     node-eval "^2.0.0"
     targz "^1.0.1"
 
+antlr4@4.13.0, antlr4@^4.8.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/antlr4/-/antlr4-4.13.0.tgz#25c0b17f0d9216de114303d38bafd6f181d5447f"
+  integrity sha512-zooUbt+UscjnWyOrsuY/tVFL4rwrAGwOivpQmvmUDE22hy/lUA467Rc1rcixyRwcRUIXFYBwv7+dClDSHdmmew==
+
 antlr4@4.8.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/antlr4/-/antlr4-4.8.0.tgz#f938ec171be7fc2855cd3a533e87647185b32b6a"
   integrity sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg==
-
-antlr4@^4.8.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/antlr4/-/antlr4-4.13.0.tgz#25c0b17f0d9216de114303d38bafd6f181d5447f"
-  integrity sha512-zooUbt+UscjnWyOrsuY/tVFL4rwrAGwOivpQmvmUDE22hy/lUA467Rc1rcixyRwcRUIXFYBwv7+dClDSHdmmew==
 
 antlr4ts@^0.5.0-alpha.4:
   version "0.5.0-alpha.4"


### PR DESCRIPTION
Fix #122 

ToDo : upgrade [@inseefr/vtl-2.0-antlr-tools ](https://github.com/InseeFr/Trevas-JS/blob/master/packages/trevas/package.json#L28) to last version inside trevas package